### PR TITLE
prettier 2.x.x does not need trailingComma: "es5"

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,4 @@
 {
-  "trailingComma": "es5",
   "tabWidth": 2,
   "semi": true,
   "singleQuote": true

--- a/src/main.user.ts
+++ b/src/main.user.ts
@@ -13,9 +13,12 @@
 
 (() => {
   // types
-  type Position = { x: number; y: number; };
+  type Position = { x: number; y: number };
   type Rect = {
-    top_left: Position; bottom_right: Position; width: number; height: number;
+    top_left: Position;
+    bottom_right: Position;
+    width: number;
+    height: number;
   };
 
   // consts
@@ -35,29 +38,29 @@
   };
 
   const zoomVideoToRect = (video: HTMLVideoElement, rect: Rect): void => {
-    const video_container =
-        document.querySelector(VIDEO_CONTAINER_SELECTOR) as HTMLDivElement |
-        null;
+    const video_container = document.querySelector(
+      VIDEO_CONTAINER_SELECTOR
+    ) as HTMLDivElement | null;
     if (video_container === null) return;
 
     const video_container_rect = video_container.getBoundingClientRect();
     const player_aspect_ratio =
-        video_container_rect.width / video_container_rect.height;
+      video_container_rect.width / video_container_rect.height;
     const selected_aspect_ratio = rect.width / rect.height;
 
-    const fit_width =
-        player_aspect_ratio < selected_aspect_ratio;  // or height?
+    const fit_width = player_aspect_ratio < selected_aspect_ratio; // or height?
 
-    const scale = fit_width ? video_container_rect.width / rect.width :
-                              video_container_rect.height / rect.height;
+    const scale = fit_width
+      ? video_container_rect.width / rect.width
+      : video_container_rect.height / rect.height;
 
     video.style.transform = `translateX(${
-        ((video_container_rect.width / 2) -
-         (rect.top_left.x + rect.width / 2)) *
-        scale}px) translateY(${
-        ((video_container_rect.height / 2) -
-         (rect.top_left.y + rect.height / 2)) *
-        scale}px) scale(${scale})`;
+      (video_container_rect.width / 2 - (rect.top_left.x + rect.width / 2)) *
+      scale
+    }px) translateY(${
+      (video_container_rect.height / 2 - (rect.top_left.y + rect.height / 2)) *
+      scale
+    }px) scale(${scale})`;
     video.style.transition = 'all 0.3s ease';
   };
 
@@ -103,8 +106,9 @@
   };
 
   const setupZoomFeature = (): void => {
-    const video =
-        document.querySelector(VIDEO_SELECTOR) as HTMLVideoElement | null;
+    const video = document.querySelector(
+      VIDEO_SELECTOR
+    ) as HTMLVideoElement | null;
     if (video === null) return;
 
     video.addEventListener('mousedown', handleDragStart);
@@ -112,8 +116,9 @@
   };
 
   const onKeyPress = (e: KeyboardEvent) => {
-    const video =
-        document.querySelector(VIDEO_SELECTOR) as HTMLVideoElement | null;
+    const video = document.querySelector(
+      VIDEO_SELECTOR
+    ) as HTMLVideoElement | null;
     if (video === null) return;
     if (e.key === 'r') video.style.transform = '';
   };


### PR DESCRIPTION
prettier 2.x.x changed default value for `frailingComma` to "es5".
see [release note](https://prettier.io/blog/2020/03/21/2.0.0.html)